### PR TITLE
Adds a fix for Issue 5 which resolves the null results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: go
+sudo: false
+
+matrix:
+  include:
+    - go: 1.2
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: 1.7
+    - go: 1.8
+    - go: tip
+
+install:
+  - # Skip
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/links_test.go
+++ b/links_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/yohgo/pagination"
 )
 
 // newLinksDataProvider provides data for the TestNewLinks function.

--- a/page.go
+++ b/page.go
@@ -8,9 +8,9 @@ import (
 
 // Page is a pagination page structure.
 type Page struct {
-	Links   *Links      `json:"_links"`
-	Count   int         `json:"count"`
-	Results interface{} `json:"results"`
+	Links   *Links        `json:"_links"`
+	Count   int           `json:"count"`
+	Results []interface{} `json:"results"`
 }
 
 // NewPage creates a new pagination page.
@@ -25,6 +25,11 @@ func NewPage(reqURL *url.URL, result interface{}) (*Page, error) {
 	if aType.Kind() != reflect.Slice {
 		return nil, errors.New("The provided collection is not a slice")
 	}
+	// Converts to a slice of interfaces
+	aResult := make([]interface{}, aType.Len())
+	for index := 0; index < aType.Len(); index++ {
+		aResult[index] = aType.Index(index).Interface()
+	}
 
-	return &Page{Links: NewLinks(reqURL, aType.Len()), Count: aType.Len(), Results: result}, nil
+	return &Page{Links: NewLinks(reqURL, aType.Len()), Count: aType.Len(), Results: aResult}, nil
 }

--- a/page_test.go
+++ b/page_test.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/yohgo/pagination"
 )
 
 // User contains the data required for a unique user.
@@ -23,10 +25,32 @@ var newPageDataProvider = []struct {
 	err     error
 }{
 	{
-		name: "Page creation fails due to an invalid url query",
+		name: "Page creation fails - invalid url query",
 		url:  "api.demo.com/v1/users?page=invalid_page&limit=invalid_limit&order_by=&order=invalid_order",
 		want: nil,
 		err:  errors.New("Page is invalid"),
+	},
+	{
+		name:    "Page creation fails - invalid results",
+		url:     "api.demo.com/v1/users?page=1&limit=3&order_by=name&order=asc",
+		results: "invalid results",
+		want:    nil,
+		err:     errors.New("The provided collection is not a slice"),
+	},
+	{
+		name:    "Successful page creation - no paging, no ordering, empty results",
+		url:     "api.demo.com/v1/users",
+		results: []*User{},
+		want: &pagination.Page{
+			Count: 0,
+			Links: &pagination.Links{
+				Self:     "api.demo.com/v1/users",
+				Previous: "",
+				Next:     "",
+			},
+			Results: []interface{}{},
+		},
+		err: nil,
 	},
 	{
 		name: "Successful page creation - no paging, no ordering",
@@ -41,8 +65,8 @@ var newPageDataProvider = []struct {
 				Previous: "",
 				Next:     "",
 			},
-			Results: []*User{
-				{ID: 1, Name: "John", Surname: "Smith"},
+			Results: []interface{}{
+				&User{ID: 1, Name: "John", Surname: "Smith"},
 			},
 		},
 		err: nil,
@@ -62,20 +86,13 @@ var newPageDataProvider = []struct {
 				Previous: "",
 				Next:     "",
 			},
-			Results: []*User{
-				{ID: 1, Name: "John", Surname: "Smith"},
-				{ID: 2, Name: "Jill", Surname: "Doe"},
-				{ID: 3, Name: "Paul", Surname: "Johnson"},
+			Results: []interface{}{
+				&User{ID: 1, Name: "John", Surname: "Smith"},
+				&User{ID: 2, Name: "Jill", Surname: "Doe"},
+				&User{ID: 3, Name: "Paul", Surname: "Johnson"},
 			},
 		},
 		err: nil,
-	},
-	{
-		name:    "Successful page creation - invalid results",
-		url:     "api.demo.com/v1/users?page=1&limit=3&order_by=name&order=asc",
-		results: "invalid results",
-		want:    nil,
-		err:     errors.New("The provided collection is not a slice"),
 	},
 	{
 		name: "Successful page creation - first page",
@@ -92,10 +109,10 @@ var newPageDataProvider = []struct {
 				Previous: "",
 				Self:     "api.demo.com/v1/users?page=1&limit=3&order_by=name&order=asc",
 			},
-			Results: []*User{
-				{ID: 1, Name: "John", Surname: "Smith"},
-				{ID: 2, Name: "Jill", Surname: "Doe"},
-				{ID: 3, Name: "Paul", Surname: "Johnson"},
+			Results: []interface{}{
+				&User{ID: 1, Name: "John", Surname: "Smith"},
+				&User{ID: 2, Name: "Jill", Surname: "Doe"},
+				&User{ID: 3, Name: "Paul", Surname: "Johnson"},
 			},
 		},
 		err: nil,
@@ -115,10 +132,10 @@ var newPageDataProvider = []struct {
 				Previous: "api.demo.com/v1/users?limit=3&order=asc&order_by=name&page=1",
 				Self:     "api.demo.com/v1/users?page=2&limit=3&order_by=name&order=asc",
 			},
-			Results: []*User{
-				{ID: 1, Name: "John", Surname: "Smith"},
-				{ID: 2, Name: "Jill", Surname: "Doe"},
-				{ID: 3, Name: "Paul", Surname: "Johnson"},
+			Results: []interface{}{
+				&User{ID: 1, Name: "John", Surname: "Smith"},
+				&User{ID: 2, Name: "Jill", Surname: "Doe"},
+				&User{ID: 3, Name: "Paul", Surname: "Johnson"},
 			},
 		},
 		err: nil,
@@ -137,9 +154,9 @@ var newPageDataProvider = []struct {
 				Previous: "api.demo.com/v1/users?limit=3&order=desc&order_by=surname&page=2",
 				Self:     "api.demo.com/v1/users?page=3&limit=3&order_by=surname&order=desc",
 			},
-			Results: []*User{
-				{ID: 1, Name: "John", Surname: "Smith"},
-				{ID: 2, Name: "Jill", Surname: "Doe"},
+			Results: []interface{}{
+				&User{ID: 1, Name: "John", Surname: "Smith"},
+				&User{ID: 2, Name: "Jill", Surname: "Doe"},
 			},
 		},
 		err: nil,

--- a/query_test.go
+++ b/query_test.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"github.com/yohgo/pagination"
 )
 
 // newQueryDataProvider provides data for the TestNewQuery function.


### PR DESCRIPTION
This attempts to resolve Issue #5. I have done this by creating a slice of interface{}. The is however a cost involved with this operation as it makes the NewPage a O(n) operation. As we need to scan the entire slice and copy the values over to the []interface{}. 